### PR TITLE
Filter healthy nodes in parallel

### DIFF
--- a/proxy/endpoints.py
+++ b/proxy/endpoints.py
@@ -42,14 +42,12 @@ class FairNode:
     block_ts: int = -1
 
     def __post_init__(self):
-        """Calculates endpoints after the node object is created"""
         http_port = self.base_port + SkaledPorts.HTTP_JSON.value
         ws_port = self.base_port + SkaledPorts.WS_JSON.value
         self.http_endpoint = f"{URL_PREFIXES['http']}{self.domain}:{http_port}"
         self.ws_endpoint = f"{URL_PREFIXES['ws']}{self.domain}:{ws_port}"
 
-    def fetch_block_timestamp(self):
-        """Fetches and updates the timestamp of the latest block from the node"""
+    def fetch_latest_block_timestamp(self):
         try:
             res = make_rpc_call(self.http_endpoint, 'eth_getBlockByNumber', ['latest', False])
             if res and res.ok:
@@ -60,7 +58,6 @@ class FairNode:
             self.block_ts = -1
 
     def is_accessible(self) -> bool:
-        """Checks if the node's http endpoint is responsive"""
         try:
             response = requests.head(self.http_endpoint, timeout=10)
             return response.status_code < 400
@@ -68,14 +65,12 @@ class FairNode:
             return False
 
     def is_synced(self, max_timestamp: int) -> bool:
-        """Checks if the node is synced"""
         if self.block_ts < 0:
             return False
         return abs(max_timestamp - self.block_ts) <= ALLOWED_TIMESTAMP_DIFF
 
 
 def _fetch_active_committee_nodes(fair_manager: FairManager) -> list[FairNode]:
-    """Retrieves all active nodes and converts them into FairNode objects"""
     active_committee_id = fair_manager.committee.get_active_committee_index()
     active_committee = fair_manager.committee.get_committee(active_committee_id)
     node_ids = active_committee.node_ids
@@ -92,7 +87,7 @@ def _fetch_active_committee_nodes(fair_manager: FairManager) -> list[FairNode]:
 def _filter_healthy_nodes(nodes: list[FairNode]) -> list[FairNode]:
     logger.info('Fetching block timestamps for committee nodes...')
     with ThreadPoolExecutor(max_workers=len(nodes)) as executor:
-        list(executor.map(lambda node: node.fetch_block_timestamp(), nodes))
+        list(executor.map(lambda node: node.fetch_latest_block_timestamp(), nodes))
 
     valid_timestamps = [node.block_ts for node in nodes if node.block_ts >= 0]
     if not valid_timestamps:
@@ -125,14 +120,12 @@ def _filter_healthy_nodes(nodes: list[FairNode]) -> list[FairNode]:
 
 
 def update_anchor_file(endpoints: list[str]):
-    """Overwrites the anchor endpoints file with the latest list of healthy endpoints"""
     logger.info(f'Updating anchor endpoints file with {len(endpoints)} endpoints')
     data_to_write = {'anchor_endpoints': endpoints}
     write_json(ANCHOR_FILEPATH, data_to_write)
 
 
 def generate_endpoints() -> tuple[dict, list]:
-    """Generate http and ws endpoints of active committee healthy FAIR nodes"""
     anchor_endpoints_data = read_json(ANCHOR_FILEPATH)
     anchor_endpoints = anchor_endpoints_data.get('anchor_endpoints', [])
     fair_manager = FairManager(anchor_endpoints, FAIR_CONTRACTS)

--- a/proxy/endpoints.py
+++ b/proxy/endpoints.py
@@ -17,6 +17,7 @@
 
 
 import logging
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 
 import requests
@@ -89,9 +90,9 @@ def _fetch_active_committee_nodes(fair_manager: FairManager) -> list[FairNode]:
 
 
 def _filter_healthy_nodes(nodes: list[FairNode]) -> list[FairNode]:
-    """Filters a list of nodes to return only accessible and synced ones"""
-    for node in nodes:
-        node.fetch_block_timestamp()
+    logger.info('Fetching block timestamps for committee nodes...')
+    with ThreadPoolExecutor(max_workers=len(nodes)) as executor:
+        list(executor.map(lambda node: node.fetch_block_timestamp(), nodes))
 
     valid_timestamps = [node.block_ts for node in nodes if node.block_ts >= 0]
     if not valid_timestamps:
@@ -100,18 +101,22 @@ def _filter_healthy_nodes(nodes: list[FairNode]) -> list[FairNode]:
     max_ts = max(valid_timestamps)
     logger.info(f'Maximum block timestamp across all nodes: {max_ts}')
 
-    healthy_nodes = []
-    for node in nodes:
+    def check_node_health(node: FairNode) -> FairNode | None:
         if not node.is_accessible():
             logger.warning(f'Node {node.id} ({node.http_endpoint}) is not accessible')
-            continue
+            return None
         if not node.is_synced(max_ts):
             logger.warning(
                 f'Node {node.id} ({node.http_endpoint}) is not synced. '
                 f'(Node TS: {node.block_ts}, Max TS: {max_ts})'
             )
-            continue
-        healthy_nodes.append(node)
+            return None
+        return node
+
+    logger.info('Checking health and sync status for committee nodes...')
+    with ThreadPoolExecutor(max_workers=len(nodes)) as executor:
+        results = executor.map(check_node_health, nodes)
+        healthy_nodes = [node for node in results if node is not None]
 
     logger.info(f'Found {len(healthy_nodes)} healthy and synchronized nodes')
     logger.debug(f'Healthy nodes: {healthy_nodes}')

--- a/proxy/endpoints.py
+++ b/proxy/endpoints.py
@@ -125,7 +125,7 @@ def update_anchor_file(endpoints: list[str]):
     write_json(ANCHOR_FILEPATH, data_to_write)
 
 
-def generate_endpoints() -> tuple[dict, list]:
+def generate_active_committee_endpoints() -> tuple[dict, list]:
     anchor_endpoints_data = read_json(ANCHOR_FILEPATH)
     anchor_endpoints = anchor_endpoints_data.get('anchor_endpoints', [])
     fair_manager = FairManager(anchor_endpoints, FAIR_CONTRACTS)
@@ -148,5 +148,5 @@ def generate_endpoints() -> tuple[dict, list]:
 
 
 if __name__ == '__main__':
-    endpoints = generate_endpoints()
+    endpoints = generate_active_committee_endpoints()
     print(f'Endpoints: {endpoints}')

--- a/proxy/endpoints.py
+++ b/proxy/endpoints.py
@@ -17,6 +17,7 @@
 
 
 import logging
+import random
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 
@@ -128,6 +129,7 @@ def update_anchor_file(endpoints: list[str]):
 def generate_active_committee_endpoints() -> tuple[dict, list]:
     anchor_endpoints_data = read_json(ANCHOR_FILEPATH)
     anchor_endpoints = anchor_endpoints_data.get('anchor_endpoints', [])
+    random.shuffle(anchor_endpoints)
     fair_manager = FairManager(anchor_endpoints, FAIR_CONTRACTS)
     all_nodes = _fetch_active_committee_nodes(fair_manager)
     healthy_nodes = _filter_healthy_nodes(all_nodes)

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -42,7 +42,7 @@ def main():
         nginx_endpoints, healthy_http_list = generate_endpoints()
         if healthy_http_list:
             update_anchor_file(healthy_http_list)
-            logger.info(f'The new anchor endpoints: {healthy_http_list}')
+            logger.debug(f'The new anchor endpoints: {healthy_http_list}')
             write_json(CHAIN_INFO_FILEPATH, nginx_endpoints)
             update_nginx_config(nginx_endpoints)
             send_heartbeat(HEARTBEAT_URL)

--- a/proxy/main.py
+++ b/proxy/main.py
@@ -20,7 +20,7 @@ from pathlib import Path
 from time import sleep
 
 from proxy.config import CHAIN_INFO_FILEPATH, HEARTBEAT_URL, MONITOR_INTERVAL, TMP_UPSTREAMS_FOLDER
-from proxy.endpoints import generate_endpoints, update_anchor_file
+from proxy.endpoints import generate_active_committee_endpoints, update_anchor_file
 from proxy.heartbeat import send_heartbeat
 from proxy.helper import init_default_logger, write_json
 from proxy.nginx import update_nginx_config
@@ -39,7 +39,7 @@ def main():
 
     while True:
         logger.info("Starting new endpoint collection cycle...")
-        nginx_endpoints, healthy_http_list = generate_endpoints()
+        nginx_endpoints, healthy_http_list = generate_active_committee_endpoints()
         if healthy_http_list:
             update_anchor_file(healthy_http_list)
             logger.debug(f'The new anchor endpoints: {healthy_http_list}')

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Jinja2==3.1.6
 colorful==0.5.7
 docker==7.1.0
-skale.py==7.4dev2
+skale.py==7.3dev3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Jinja2==3.1.6
 colorful==0.5.7
 docker==7.1.0
-skale.py==7.3dev3
+skale.py==7.4dev2


### PR DESCRIPTION
This pull request improves the efficiency and clarity of the endpoint health-checking logic in the proxy service by parallelizing block timestamp fetching and refactoring function and method names for better readability. The main changes include using a thread pool to speed up node status checks, renaming functions and methods for clarity, and updating logging for better diagnostics.

**Performance improvements:**

* Parallelized fetching of block timestamps and health checks for committee nodes using `ThreadPoolExecutor`, significantly improving the speed of node validation in `_filter_healthy_nodes`. [[1]](diffhunk://#diff-dd9ae9d89418fb3b165a8437b3b078651996e56d3a77f32e477bc64fafa82675R20) [[2]](diffhunk://#diff-dd9ae9d89418fb3b165a8437b3b078651996e56d3a77f32e477bc64fafa82675L92-R90) [[3]](diffhunk://#diff-dd9ae9d89418fb3b165a8437b3b078651996e56d3a77f32e477bc64fafa82675L103-R114)

**Code clarity and maintainability:**

* Renamed `fetch_block_timestamp` to `fetch_latest_block_timestamp` in the `FairNode` class for better clarity.
* Renamed `generate_endpoints` to `generate_active_committee_endpoints` throughout the codebase for clearer intent, including updating all usages and imports. [[1]](diffhunk://#diff-dd9ae9d89418fb3b165a8437b3b078651996e56d3a77f32e477bc64fafa82675L123-R128) [[2]](diffhunk://#diff-dd9ae9d89418fb3b165a8437b3b078651996e56d3a77f32e477bc64fafa82675L153-R151) [[3]](diffhunk://#diff-b72a2d990f788df650fe2c26d090de900d56a9be197e6a2a9ac9465187bb8f26L23-R23) [[4]](diffhunk://#diff-b72a2d990f788df650fe2c26d090de900d56a9be197e6a2a9ac9465187bb8f26L42-R45)

**Logging improvements:**

* Enhanced logging to provide more granular information during node health checking and endpoint updates. [[1]](diffhunk://#diff-dd9ae9d89418fb3b165a8437b3b078651996e56d3a77f32e477bc64fafa82675L92-R90) [[2]](diffhunk://#diff-dd9ae9d89418fb3b165a8437b3b078651996e56d3a77f32e477bc64fafa82675L103-R114) [[3]](diffhunk://#diff-dd9ae9d89418fb3b165a8437b3b078651996e56d3a77f32e477bc64fafa82675L123-R128) [[4]](diffhunk://#diff-b72a2d990f788df650fe2c26d090de900d56a9be197e6a2a9ac9465187bb8f26L42-R45)