### PR TITLE
Make SSL certs optional in nginx config

### DIFF
--- a/config/nginx.conf.template
+++ b/config/nginx.conf.template
@@ -20,9 +20,11 @@ http {
 
     server {
         listen 80;
+        #SSL_CONFIG_START
         listen 443 ssl;
         ssl_certificate /data/server.crt;
         ssl_certificate_key /data/server.key;
+        #SSL_CONFIG_END
         server_name _;
 
         limit_req zone=one burst=100;

--- a/scripts/run_proxy.sh
+++ b/scripts/run_proxy.sh
@@ -37,7 +37,7 @@ if [[ "$USE_ALB" == "True" ]]; then
     sed "/${SSL_START_MARKER}/,/${SSL_END_MARKER}/d" "$TEMPLATE_FILE" > "$TARGET_FILE"
 else
     # Remove the ALB real IP configuration block between markers from the template
-    sed "/${START_MARKER}/,/${END_MARKER}/d" "$TEMPLATE_FILE" > "$TARGET_FILE"
+    sed "/${REAL_IP_START_MARKER}/,/${REAL_IP_END_MARKER}/d" "$TEMPLATE_FILE" > "$TARGET_FILE"
 fi
 
 cd "$PROJECT_DIR"

--- a/scripts/run_proxy.sh
+++ b/scripts/run_proxy.sh
@@ -15,8 +15,11 @@ TARGET_FILE="$CONFIG_DIR/nginx.conf"
 DATA_DIR="$PROJECT_DIR/data"
 ANCHOR_FILE="$DATA_DIR/anchor_endpoints.json"
 
-START_MARKER="#REAL_IP_CONFIG_START"
-END_MARKER="#REAL_IP_CONFIG_END"
+REAL_IP_START_MARKER="#REAL_IP_CONFIG_START"
+REAL_IP_END_MARKER="#REAL_IP_CONFIG_END"
+
+SSL_START_MARKER="#SSL_CONFIG_START"
+SSL_END_MARKER="#SSL_CONFIG_END"
 
 if [ ! -f "$TEMPLATE_FILE" ]; then
     echo "ERROR: Nginx template file is not found at $TEMPLATE_FILE"
@@ -30,7 +33,8 @@ fi
 
 
 if [[ "$USE_ALB" == "True" ]]; then
-    cp "$TEMPLATE_FILE" "$TARGET_FILE"
+    # Remove the SSL configuration block between markers from the template
+    sed "/${SSL_START_MARKER}/,/${SSL_END_MARKER}/d" "$TEMPLATE_FILE" > "$TARGET_FILE"
 else
     # Remove the ALB real IP configuration block between markers from the template
     sed "/${START_MARKER}/,/${END_MARKER}/d" "$TEMPLATE_FILE" > "$TARGET_FILE"


### PR DESCRIPTION
This pull request updates the Nginx configuration and the `run_proxy.sh` script to support conditional inclusion of SSL configuration blocks based on the `USE_ALB` environment variable. The main focus is to make SSL configuration optional and improve marker naming consistency.

**Nginx configuration and script improvements:**

* Added SSL configuration block in `nginx.conf.template` delimited by `#SSL_CONFIG_START` and `#SSL_CONFIG_END` markers to allow conditional inclusion.
* Updated `run_proxy.sh` to define separate marker variables for both SSL and real IP configuration blocks, renaming the real IP markers for clarity.
* Modified the script logic so that when `USE_ALB` is `True`, the SSL configuration block is removed from the generated Nginx config; otherwise, the real IP configuration block is removed.