### PR TITLE
Add timeout to Heartbeat request

### DIFF
--- a/proxy/heartbeat.py
+++ b/proxy/heartbeat.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 def send_heartbeat(heartbeat_url):
     if heartbeat_url:
         try:
-            response = requests.get(heartbeat_url)
+            response = requests.get(heartbeat_url, timeout=10)
             if response.status_code == 200:
                 logger.info('Heartbeat signal is successfully sent')
             else:


### PR DESCRIPTION
This pull request makes a minor improvement to the `send_heartbeat` function in `proxy/heartbeat.py` by adding a timeout to the HTTP request. This change helps prevent the function from hanging indefinitely if the heartbeat server does not respond.